### PR TITLE
Fix post users and replies count

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,6 +1,6 @@
 export const findById = (resources, id) => {
   if (!resources) return null;
-  resources.find((resource) => resource.id === id);
+  return resources.find((resource) => resource.id === id);
 };
 
 export const upsert = (resources, resource) => {

--- a/src/pages/PageThreadShow.vue
+++ b/src/pages/PageThreadShow.vue
@@ -43,8 +43,9 @@ threadsStore.fetchThread({ id: props.id }).then(async (t) => {
   await usersStore.fetchUser({ id: thread.value.userId });
 
   thread.value.posts.forEach(async (postId) => {
-    await postsStore.fetchPost({ id: postId });
-    usersStore.fetchUser({ id: thread.value.userId });
+    const post = await postsStore.fetchPost({ id: postId });
+
+    usersStore.fetchUser({ id: post.userId });
   });
 });
 

--- a/src/pages/PageThreadShow.vue
+++ b/src/pages/PageThreadShow.vue
@@ -37,9 +37,11 @@ const props = defineProps({
   id: { type: String, required: true },
 });
 
-const thread = ref(null);
+const thread = computed(() => {
+  return threadsStore.thread(props.id);
+});
+
 threadsStore.fetchThread({ id: props.id }).then(async (t) => {
-  thread.value = t;
   await usersStore.fetchUser({ id: thread.value.userId });
 
   thread.value.posts.forEach(async (postId) => {


### PR DESCRIPTION
A few issues here. 
1. the findById function wasn't returning anything
2. My prior solution was setting the thread to a new reactive variable instead of using the getter in the threadStore. This uses the getter instead and thus makes the repliesCount, contributorsCount, etc work
3. You were passing in the threads userId to fetch user info. You need to pass in the userId on each of the posts to get the user data to display on each post

Hope this helps!