### PR TITLE
fix: if no thread return null

### DIFF
--- a/src/stores/ThreadsStore.js
+++ b/src/stores/ThreadsStore.js
@@ -16,6 +16,7 @@ export const useThreadsStore = defineStore("ThreadsStore", {
     thread: (state) => {
       return (id) => {
         const thread = findById(state.threads, id);
+        if (!thread) return null;
         const usersStore = useUsersStore();
         return {
           ...thread,


### PR DESCRIPTION
Ah, yes. Nice catch!
The issue here is that the computed prop runs immediately before `fetchThread` is called or finishes so to start there is no thread. It makes sense then, if there is no matching thread in the store to return null. 

Then once the request to fetch the thread is complete, the computed prop will automatically update with the proper thread since it relies on the threads state from the `threadsStore`